### PR TITLE
Added validation addon version in seedstack-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <solr-addon.version>2.0.0</solr-addon.version>
         <spring-bridge-addon.version>3.0.1</spring-bridge-addon.version>
         <swagger-addon.version>2.0.0</swagger-addon.version>
+        <validation-addon.version>2.3.0</validation-addon.version>
         <w20-bridge-addon.version>3.0.0</w20-bridge-addon.version>
         <web-services-addon.version>3.0.0</web-services-addon.version>
 

--- a/seedstack-bom/pom.xml
+++ b/seedstack-bom/pom.xml
@@ -326,6 +326,13 @@
                 <version>${swagger-addon.version}</version>
             </dependency>
 
+            <!-- Validation add-on -->
+            <dependency>
+                <groupId>org.seedstack.addons.validation</groupId>
+                <artifactId>validation</artifactId>
+                <version>${validation-addon.version}</version>
+            </dependency>
+
             <!-- W20 bridge add-on -->
             <dependency>
                 <groupId>org.seedstack.addons.w20</groupId>


### PR DESCRIPTION
The validation addon was not present in the 16.11.2 version of the seedstack-bom. So I added it.