### PR TITLE
Update to hibernate-validator v6.0.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <java-compiler.version>1.8</java-compiler.version>
         <docker-maven-plugin.version>0.27.2</docker-maven-plugin.version>
         <hibernate.version>5.4.10.Final</hibernate.version>
-        <hibernate-validator.version>6.0.16.Final</hibernate-validator.version>
+        <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
         <hikari.version>2.6.3</hikari.version>
         <postgresql.version>42.1.1</postgresql.version>
         <mysql.version>8.0.15</mysql.version>


### PR DESCRIPTION
Previous version v6.0.16.Final contains a ssa vunerability. Adviced version is 6.0.18